### PR TITLE
base and component extension

### DIFF
--- a/src/components/pages/components/ContentRenderer.tsx
+++ b/src/components/pages/components/ContentRenderer.tsx
@@ -34,6 +34,7 @@ import { DefaultRoutes } from '../../../types/routing';
 import { setPersistState } from '../../../store/appSlice';
 import { RootState } from '../../../store/rootReducer';
 import { getTranslatedMarkdownPath } from '../../../hooks/useTranslatedMarkdown';
+import { componentBuilder } from '../../../extension/config';
 
 
 interface ContentRendererProps {
@@ -112,7 +113,7 @@ const ContentRenderer: React.FC<ContentRendererProps> = (props) => {
           className={item.className}
           minHeight={item.config.minHeight}
           posterUrl={item.config.posterUrlKey ? t(`${item.itemKey}.${item.config.posterUrlKey}`) : undefined}
-          sources={item.config.videoSources.map(vs => {
+          sources={item.config.videoSources.map((vs:any) => {
             // console.log(t(`${item.itemKey}.${vs.type}`))
             return {
               src: t(`${item.itemKey}.${vs.urlKey}`),
@@ -194,7 +195,7 @@ const ContentRenderer: React.FC<ContentRendererProps> = (props) => {
           className={item.className}
           containerClassName={item.config.className}
           useTitle={item.config.useTitle}
-          images={item.config.images.map(image => {
+          images={item.config.images.map((image:any) => {
             image.altKey = t(`${item.itemKey}.${image.altKey}`);
             return image
           })}
@@ -205,7 +206,7 @@ const ContentRenderer: React.FC<ContentRendererProps> = (props) => {
           key={item.itemKey}
           className={item.className}
           title={t(`${item.itemKey}.title`)}
-          items={item.config.links.map(link => {
+          items={item.config.links.map((link:any) => {
             return {
               label: t(`${item.itemKey}.${link.linkKey}`),
               type: link.type,
@@ -241,6 +242,9 @@ const ContentRenderer: React.FC<ContentRendererProps> = (props) => {
         return <p
           key={item.itemKey}
         >todo</p>
+
+      case 'extension':
+        return componentBuilder(item, i18n.language);
     }
     return <div
       key={item.itemKey}

--- a/src/extension/config.ts
+++ b/src/extension/config.ts
@@ -1,0 +1,21 @@
+import { ReactNode } from "react";
+import { PageItem } from "../types/pagesConfig";
+import { ExtensionConfig, componentBuilderFunc } from "./types";
+
+var extension : ExtensionConfig = {}
+
+export const installExtension = (cfg: ExtensionConfig) => {
+    extension = cfg;
+}
+
+export const registerComponentBuilder = (fn: componentBuilderFunc):void => {
+    extension.componentBuilder = fn;
+}
+
+export const componentBuilder = (item:PageItem, language: string) : ReactNode => {
+    if(extension.componentBuilder) {
+        return extension.componentBuilder(item, language);
+    }
+    return null;
+}
+

--- a/src/extension/types.ts
+++ b/src/extension/types.ts
@@ -1,0 +1,15 @@
+
+
+import {ReactNode} from 'react';
+import { PageItem } from '../types/pagesConfig';
+
+export type componentBuilderFunc = (item : PageItem, language: string)=> ReactNode
+
+export interface ExtensionConfig {
+    componentBuilder?: componentBuilderFunc;
+}
+
+export interface ExtensionComponentConfig {
+    type: 'extension'
+}
+  

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,10 @@
 import AppCore from './AppCore';
 import { initI18n } from './i18n';
 import store from './store/store';
-
+import { installExtension } from './extension/config';
 export {
   AppCore,
   initI18n,
   store,
+  installExtension,
 }

--- a/src/types/appConfig.ts
+++ b/src/types/appConfig.ts
@@ -1,3 +1,5 @@
+import { ExtensionConfig } from '../extension/types';
+
 export interface AppConfig {
   instanceId: string;
   languages: Array<LanguageConfig>;
@@ -13,3 +15,4 @@ export interface AvatarConfig {
   avatarId: string;
   url: string;
 }
+

--- a/src/types/pagesConfig.ts
+++ b/src/types/pagesConfig.ts
@@ -1,3 +1,4 @@
+import { ExtensionComponentConfig } from "../extension";
 import { DefaultRoutes } from "./routing";
 
 export interface PagesConfig {
@@ -34,12 +35,12 @@ export interface PageItem {
   config: PageItemConfig;
 }
 
+
 type PageItemConfig = TeaserImageConfig | RouterComponentConfig |
   MarkdownComponentConfig | ImageCardConfig | LoginCardConfig | VideoConfig | ImageConfig |
   AccordionListConfig | SimpleCard | SystemInfoConfig | AccountSettingsConfig |
   CommunicationSettingsConfig | DeleteAccountConfig | LogoCreditsConfig |
-  SurveyListConfig | LinkListConfig | MapDataSeriesConfig | LineWithScatterChartConfig
-
+  SurveyListConfig | LinkListConfig | MapDataSeriesConfig | LineWithScatterChartConfig | ExtensionComponentConfig
 
 export interface MarkdownComponentConfig {
   type: 'markdown';
@@ -167,3 +168,4 @@ export interface SurveyListConfig {
 export interface RouterComponentConfig {
   type: 'router';
 }
+


### PR DESCRIPTION
Proposal to enable a 'extension' to the core component

The principle is the core is aware of the extension but only that some hooks can be defined to delegate (like to have extra component not managed by the code but for which the creation is delegated to the registred extension).

Plan would be to have the same mechanism for the user storage (the store could have extra component) for which the core deleguate the management to the extension.

I'm not sure this pull request is ready to go, but it can be a starting point to discuss !
