### PR TITLE
SignupSuccess now correctly renew the auth token

### DIFF
--- a/src/components/dialogs/GlobalDialogs/SignupSuccess.tsx
+++ b/src/components/dialogs/GlobalDialogs/SignupSuccess.tsx
@@ -73,22 +73,29 @@ const SignupSuccess: React.FC = () => {
   const onReloadUser = async () => {
     try {
       setLoading(true)
+
       const user = (await getUserReq()).data;
-      dispatch(userActions.setUser(user));
-      console.log(user)
       if (user.account.accountConfirmedAt > 0) {
+
+        /*
+        *  In case the account was confirmed, set the freshly acquired user state **after** renewing the token.
+        *  This is done in order to avoid race conditions with other components that depend on the user state.
+        *  Differently, those components might fail performing api requests since they would be using a weaker token.
+        */ 
         await renewToken();
+        dispatch(userActions.setUser(user));
+
         handleClose();
       } else {
         setError2(t('dialogs:signupSuccess.errors.verifyEmailFirst'));
       }
+
     } catch (e: any) {
       console.error(e);
     } finally {
       setLoading(false)
     }
   }
-
 
   const handleClose = () => {
     setError('');


### PR DESCRIPTION
This correct a bug where the list of active surveys wouldn't load after the sign up process completed

Fixes #3       