### PR TITLE
Env parameters

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,5 @@
+## Usable env variables
+
 REACT_APP_CONTENT_URL=/static-content
 REACT_APP_DEFAULT_LANGUAGE=en
 REACT_APP_FALLBACK_LANGUAGE=en
@@ -5,7 +7,14 @@ REACT_APP_FALLBACK_LANGUAGE=en
 REACT_APP_DEFAULT_INSTANCE=<instanceID>
 REACT_APP_API_BASE_URL=<backend_server_address>
 
+# If the server is configured to use Google Recaptca
 REACT_APP_USE_RECAPTCHA=true
 REACT_APP_RECAPTCHA_SITEKEY=<recaptcha_sitekey>
 
 REACT_APP_DISABLE_SIGNUP=false
+
+# Optional width of the consent dialog (must be 'sm','lg' or 'xl' values) any other will use default
+REACT_APP_CONSENT_DIALOG_WIDTH=
+
+#
+REACT_APP_USE_2FA_SIGNUP=true

--- a/readme.md
+++ b/readme.md
@@ -11,6 +11,10 @@ Publish:
 yarn publish
 ```
 
+## Configuration
+
+Some environment variables can be used in the client website to configure some behaviors of this library the list is in [.env](.env) file of this repository
+
 ## License
 
 [Apache License 2.0](LICENSE)

--- a/src/components/dialogs/GlobalDialogs/Signup.tsx
+++ b/src/components/dialogs/GlobalDialogs/Signup.tsx
@@ -26,10 +26,9 @@ import { setAppAuth } from '../../../store/appSlice';
 import { setDefaultAccessTokenHeader } from '../../../api/instances/authenticatedApi';
 import { userActions } from '../../../store/userSlice';
 import { getErrorMsg } from '../../../api/utils';
+import { parseBooleanFlag } from '../../../utils/parseBooleanFlag';
 
 const marginBottomClass = "mb-2";
-
-
 
 interface SignupFormData {
   email: string;
@@ -64,6 +63,18 @@ const signUpInfoCheckStyle: React.CSSProperties = {
   zIndex: -2,
 }
 
+type DialogSize = 'sm' | 'lg' | 'xl';
+
+const consentDialogSize = (): DialogSize | undefined => {
+  const s = process.env.REACT_APP_CONSENT_DIALOG_WIDTH ?? undefined;
+  if(s === 'sm' || s === 'lg' || s == 'xl') {
+    return s;
+  }
+  return undefined;
+}
+
+const use2FA = parseBooleanFlag(process.env.REACT_APP_USE_2FA_SIGNUP, true, false);
+
 const SignupForm: React.FC<SignupFormProps> = (props) => {
   const { t, i18n } = useTranslation(['dialogs']);
   const [signupData, setSignupData] = useState(props.initialSignupData ? props.initialSignupData : {
@@ -88,6 +99,7 @@ const SignupForm: React.FC<SignupFormProps> = (props) => {
 
   const reCaptchaSiteKey = process.env.REACT_APP_RECAPTCHA_SITEKEY ? process.env.REACT_APP_RECAPTCHA_SITEKEY : '';
   const useRecaptcha = process.env.REACT_APP_USE_RECAPTCHA === 'true';
+
   const recaptchaRef = useRef<ReCAPTCHA>(null);
 
   useEffect(() => {
@@ -97,6 +109,7 @@ const SignupForm: React.FC<SignupFormProps> = (props) => {
       confirmPassword: '',
       infoCheck: '',
     });
+
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.initialSignupData])
 
@@ -139,9 +152,9 @@ const SignupForm: React.FC<SignupFormProps> = (props) => {
   const confirmPasswordInputLabel = t('signup.confirmPasswordInputLabel');
   const confirmPasswordPlaceholder = t('signup.confirmPasswordInputLabel');
 
+  const dialogSize = consentDialogSize();
   return (
     <React.Fragment>
-
       {infoText && infoText.length > 0 ?
         <AlertBox
           type="info"
@@ -342,6 +355,7 @@ const SignupForm: React.FC<SignupFormProps> = (props) => {
 
       </form>
       <ConsentDialog
+        size={dialogSize}
         open={openPrivacyConsent}
         title={t("privacyConsent.title")}
         content={privacyConsentText.content}
@@ -357,6 +371,7 @@ const SignupForm: React.FC<SignupFormProps> = (props) => {
         }}
       />
       <ConsentDialog
+        size={dialogSize}
         open={openRecaptchaConsent}
         title={t("recaptchaConsent.title")}
         content={recaptchaConsentText.content}
@@ -421,7 +436,7 @@ const Signup: React.FC = () => {
         instanceId: instanceId,
         preferredLanguage: i18n.language,
         wantsNewsletter: true,
-        use2fa: true
+        use2fa: use2FA
       }, data.captchaToken);
 
       // TODO: update user correctly

--- a/src/components/dialogs/GlobalDialogs/Signup.tsx
+++ b/src/components/dialogs/GlobalDialogs/Signup.tsx
@@ -67,7 +67,7 @@ type DialogSize = 'sm' | 'lg' | 'xl';
 
 const consentDialogSize = (): DialogSize | undefined => {
   const s = process.env.REACT_APP_CONSENT_DIALOG_WIDTH ?? undefined;
-  if(s === 'sm' || s === 'lg' || s == 'xl') {
+  if(s === 'sm' || s === 'lg' || s === 'xl') {
     return s;
   }
   return undefined;

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import * as studyAPI from './api/studyAPI';
 import * as userAPI from './api/userAPI';
 import { dialogActions } from './store/dialogSlice';
 import { appActions } from './store/appSlice';
+import { userActions } from './store/userSlice';
 import { useAuthTokenCheck } from "./hooks/useAuthTokenCheck";
 import PreventAccidentalNavigationPrompt from './components/misc/PreventAccidentalNavigationPrompt';
 import InternalNavigator from './components/misc/InternalNavigator';
@@ -12,6 +13,7 @@ import InternalNavigator from './components/misc/InternalNavigator';
 const coreReduxActions = {
   appActions,
   dialogActions,
+  userActions
 }
 
 export {

--- a/src/utils/parseBooleanFlag.ts
+++ b/src/utils/parseBooleanFlag.ts
@@ -1,0 +1,11 @@
+
+export const parseBooleanFlag = (v: string|undefined, empty: boolean, other: boolean ):boolean => {
+  const b = (v ?? '').toLowerCase().trim();
+  if(b === '') {
+    return empty;
+  }
+  if(b === "1" || b === "true" || b === "on") {
+    return true;
+  }
+  return other;
+}


### PR DESCRIPTION
Add 2 envirnoment variables to be able to control
- use of 2FA for a newly created account in case the platform dont support it 
- consent dialog size

if use vars are not used, default behaviour is preserved (yes for 2FA, and undefined for size so use the default of Dialog component)